### PR TITLE
Feat/post message id for user

### DIFF
--- a/alert_process.php
+++ b/alert_process.php
@@ -1,0 +1,53 @@
+<?php
+
+var_dump($_POST);
+
+if( !empty($_POST['btn_alert'])){
+
+  if( !empty($_POST['alert_message']) ){
+
+    $current_date = date("Y-m-d H:i:s");
+
+      // トランザクション開始
+      $pdo->beginTransaction();
+
+      try {
+
+          // SQL作成
+          $stmt = $pdo->prepare("INSERT INTO alert_message (message_id, post_date) VALUES ( :message_id, :current_date)");
+
+          // 値をセット
+          $stmt->bindValue( ':message_id', $_POST['alert_message'], PDO::PARAM_STR);
+          $stmt->bindValue( ':current_date', $current_date, PDO::PARAM_STR);
+
+          // SQLクエリの実行
+          $res = $stmt->execute();
+
+          // コミット
+          $res = $pdo->commit();
+
+      } catch(Exception $e) {
+
+          // エラーが発生した時はロールバック
+          $pdo->rollBack();
+      }
+      
+      
+      if( $res ) {
+        $_SESSION['success_message'] = '通報しました。';
+      } else {
+        $error_message[] = '通報に失敗しました。';
+      }
+
+      // プリペアドステートメントを削除
+      $stmt = null;
+
+      header('Location: ./');
+      exit;
+      }
+  }
+
+$pdo = null;
+
+?>
+

--- a/alert_process.php
+++ b/alert_process.php
@@ -1,5 +1,42 @@
 <?php
 
+// データベースの接続情報
+define( 'DB_HOST', 'localhost');
+define( 'DB_USER', 'root');
+define( 'DB_PASS', 'root');
+define( 'DB_NAME', 'board');
+
+// タイムゾーン設定
+date_default_timezone_set('Asia/Tokyo');
+
+// 変数の初期化
+$current_date = null;
+$message = array();
+$message_array = array();
+$error_message = array();
+$pdo = null;
+$stmt = null;
+$res = null;
+$option = null;
+
+session_start();
+
+// データベースに接続
+try {
+
+    $option = array(
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::MYSQL_ATTR_MULTI_STATEMENTS => false
+    );
+    $pdo = new PDO('mysql:charset=UTF8;dbname='.DB_NAME.';host='.DB_HOST , DB_USER, DB_PASS, $option);
+
+} catch(PDOException $e) {
+
+    // 接続エラーのときエラー内容を取得する
+    $error_message[] = $e->getMessage();
+}
+
+
 var_dump($_POST);
 
 if( !empty($_POST['btn_alert'])){

--- a/alert_process.php
+++ b/alert_process.php
@@ -36,9 +36,6 @@ try {
     $error_message[] = $e->getMessage();
 }
 
-
-var_dump($_POST);
-
 if( !empty($_POST['btn_alert'])){
 
   if( !empty($_POST['alert_message']) ){

--- a/alert_process.php
+++ b/alert_process.php
@@ -36,9 +36,13 @@ try {
     $error_message[] = $e->getMessage();
 }
 
-if( !empty($_POST['btn_alert'])){
+if( !empty($_POST['btn_alert']) && !empty($_POST['alert_message']) ){
+  $sql = "SELECT message_id FROM alert_message WHERE message_id = ".$_POST['alert_message'];
+  $alert_message_id = $pdo->query($sql);
+  foreach( $alert_message_id as $value);
 
-  if( !empty($_POST['alert_message']) ){
+  // すでに通報されている場合は、通報のコメントのみ表示する
+  if(  $_POST['alert_message'] !== $value[0] ){
 
     $current_date = date("Y-m-d H:i:s");
 
@@ -66,7 +70,7 @@ if( !empty($_POST['btn_alert'])){
           $pdo->rollBack();
       }
       
-      
+
       if( $res ) {
         $_SESSION['success_message'] = '通報しました。';
       } else {
@@ -76,10 +80,15 @@ if( !empty($_POST['btn_alert'])){
       // プリペアドステートメントを削除
       $stmt = null;
 
-      header('Location: ./');
+      header('Location: ./index.php');
       exit;
-      }
-  }
+
+    }else{
+      $_SESSION['success_message'] = '通報しました。';
+      header('Location: ./index.php');
+      exit;
+    }
+}
 
 $pdo = null;
 

--- a/index.php
+++ b/index.php
@@ -110,11 +110,11 @@ if( !empty($_POST['btn_submit']) ) {
 if( !empty($pdo) ) {
 
     // メッセージのデータを取得する
-    $sql = "SELECT view_name,message,post_date FROM message ORDER BY post_date DESC";
+    $sql = "SELECT * FROM message ORDER BY post_date DESC";
     $message_array = $pdo->query($sql);
 }
 
-require("./alert_process.php");
+// require("./alert_process.php");
 
 // データベースの接続を閉じる
 $pdo = null;
@@ -163,12 +163,15 @@ $pdo = null;
         <time><?php echo date('Y年m月d日 H:i', strtotime($value['post_date'])); ?></time>
     </div>
     <p><?php echo nl2br( htmlspecialchars( $value['message'], ENT_QUOTES, 'UTF-8') ); ?></p>
-</article>
+
+<?php var_dump($value['id']);?>		
 		<!-- 通報 -->
-		<form method="post">
-      <input type="hidden" name="alert_message" value="<?php $value['id'] ?>">
+		<form method="post" action="alert_process.php">
+			<input type="hidden" name="alert_message" value="<?php if( !empty($value['id']) ){ echo htmlspecialchars( $value['id'], ENT_QUOTES, 'UTF-8'); } ?>">
       <input type="submit" name="btn_alert" value="通報">
   	</form>
+		
+</article>
 <?php } ?>
 <?php } ?>
 </section>

--- a/index.php
+++ b/index.php
@@ -114,6 +114,8 @@ if( !empty($pdo) ) {
     $message_array = $pdo->query($sql);
 }
 
+require("./alert_process.php");
+
 // データベースの接続を閉じる
 $pdo = null;
 
@@ -162,6 +164,11 @@ $pdo = null;
     </div>
     <p><?php echo nl2br( htmlspecialchars( $value['message'], ENT_QUOTES, 'UTF-8') ); ?></p>
 </article>
+		<!-- 通報 -->
+		<form method="post">
+      <input type="hidden" name="alert_message" value="<?php $value['id'] ?>">
+      <input type="submit" name="btn_alert" value="通報">
+  	</form>
 <?php } ?>
 <?php } ?>
 </section>

--- a/index.php
+++ b/index.php
@@ -163,8 +163,7 @@ $pdo = null;
         <time><?php echo date('Y年m月d日 H:i', strtotime($value['post_date'])); ?></time>
     </div>
     <p><?php echo nl2br( htmlspecialchars( $value['message'], ENT_QUOTES, 'UTF-8') ); ?></p>
-
-<?php var_dump($value['id']);?>		
+		
 		<!-- 通報 -->
 		<form method="post" action="alert_process.php">
 			<input type="hidden" name="alert_message" value="<?php if( !empty($value['id']) ){ echo htmlspecialchars( $value['id'], ENT_QUOTES, 'UTF-8'); } ?>">


### PR DESCRIPTION
## チケットへのリンク

*  #1 

## やったこと

* 一般の掲示板画面に通報ボタンを追加
* 通知ボタンを押すとalert_messageテーブルに通報情報を登録する
* すでにDBに登録されているmessage_idであれば、登録せずに、登録通知のみ表示

## やらないこと

* 管理者ページで通報を表示する画面を作成
* 削除するときにalert_messageテーブルから対象レコードを削除する

## 動作確認

■alert_message テーブルの構造
![image](https://user-images.githubusercontent.com/83944000/121620158-ce542380-caa4-11eb-816a-82ab1fe3a77f.png)

■新規登録をする
![post_alert](https://user-images.githubusercontent.com/83944000/121621651-87b3f880-caa7-11eb-8698-b1653883cec9.gif)


■すでに登録されている
（５回、同じメッセージの通知ボタンを押したが、DBにはすでに登録されているので５回登録されない）
![already_post_alert](https://user-images.githubusercontent.com/83944000/121621528-47ed1100-caa7-11eb-8f04-687fb4883a1a.gif)



## その他

* なし

## Mergeをする前に

- [x] 今回の変更により影響がある部分をテストして動作確認済みです
- [x] 最新の変更を全て取り込んで反映しています
