### PR TITLE
feat/ create message alert individual deletion

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -117,7 +117,7 @@ $alert_report_count = $alert_value[0];
 		</form>
 	</div>
 	<div>
-		<a href="./alert_admin.php" >通知レポート <?php if( $alert_report_count !== 0){ echo "(".$alert_report_count.")"; } ?></a>
+		<a href="./alert.php" >通知レポート <?php if( $alert_report_count !== 0){ echo "(".$alert_report_count.")"; } ?></a>
 	</div>
 </div>
 

--- a/alert.php
+++ b/alert.php
@@ -74,6 +74,10 @@ $pdo = null;
 <title>ひと言掲示板 管理ページ（通報レポート）</title>
 <style>
 	<?php require("./main.css"); ?>
+  .alert_delete_button{
+    display: flex;
+    justify-content: flex-end;
+  }
 </style>
 </head>
 <body>
@@ -99,6 +103,12 @@ $pdo = null;
           <p><a href="delete.php?message_id=<?php echo $value['id']; ?>">削除</a></p>
       </div>
       <p><?php echo nl2br( htmlspecialchars( $value['message'], ENT_QUOTES, 'UTF-8') ); ?></p>
+      <div class="alert_delete_button">
+        <form method="post" action="alert_process.php">
+          <input type="hidden" name="alert_message_delete" value="<?php if( !empty($value['id']) ){ echo htmlspecialchars( $value['id'], ENT_QUOTES, 'UTF-8'); } ?>">
+          <input type="submit" name="btn_alert_delete" value="通報一覧から削除">
+        </form>
+      </div>
   </article>
   <?php } ?>
 <?php } ?>

--- a/alert_process.php
+++ b/alert_process.php
@@ -90,6 +90,39 @@ if( !empty($_POST['btn_alert']) && !empty($_POST['alert_message']) ){
     }
 }
 
+
+// 通報DBから削除
+if( !empty($_POST['btn_alert_delete']) ){
+  // トランザクション開始
+  $pdo->beginTransaction();
+
+  try {
+
+      // SQL作成
+      $alert_stmt = $pdo->prepare("DELETE FROM alert_message WHERE message_id = :delete_alert_message_id");
+
+      // 値をセット
+      $alert_stmt->bindValue( ':delete_alert_message_id', $_POST['alert_message_delete'], PDO::PARAM_INT);
+
+      // SQLクエリの実行
+      $alert_stmt->execute();
+
+      // コミット
+      $res = $pdo->commit();
+
+  } catch(Exception $e) {
+
+      // エラーが発生した時はロールバック
+      $pdo->rollBack();
+  }
+
+  // 削除に成功したら一覧に戻る
+  if( $res ) {
+      header("Location: ./alert.php");
+      exit;
+  }
+}
+
 $pdo = null;
 
 ?>


### PR DESCRIPTION
## チケットへのリンク

*  #1 

## やったこと

* 管理者の通報画面から個別で通報削除できるようにボタンを設置

## やらないこと

* なし

## 動作確認

■動作
１通報ページに個別通報削除ボタンを押す
２alert_messageテーブルから対象レコードを削除
３個別通報ボタンを押したら通報一覧から削除

![delete_alert_all](https://user-images.githubusercontent.com/83944000/121640311-b5f60000-cac8-11eb-8863-b3e790a0b69d.gif)


## その他

* なし

## Mergeをする前に

- [x] 今回の変更により影響がある部分をテストして動作確認済みです
- [x] 最新の変更を全て取り込んで反映しています
