### PR TITLE
feat/search for message and view_name

### DIFF
--- a/index.php
+++ b/index.php
@@ -180,6 +180,12 @@ $pdo = null;
     <a href="./admin.php">管理ページ</a>
 </form>
 <hr>
+<label>検索</label>
+  <form action="search_view.php" method="post">
+      <input type="text" name="search_word">
+      <input type="submit" name="btn_search" value="投稿を検索">
+  </form>
+  <hr>
 <section>
 <?php if( !empty($message_array) ): ?>
 <?php foreach( $message_array as $value ): ?>
@@ -194,7 +200,7 @@ $pdo = null;
 		<!-- 通報 -->
 		<form method="post" action="alert_process.php">
 			<input type="hidden" name="alert_message" value="<?php if( !empty($value['id']) ){ echo htmlspecialchars( $value['id'], ENT_QUOTES, 'UTF-8'); } ?>">
-      <input type="submit" name="btn_alert" value="通報">
+        <input type="submit" name="btn_alert" value="通報">
   	</form>
 		
 </article>

--- a/search_process.php
+++ b/search_process.php
@@ -1,0 +1,63 @@
+<?php
+
+// データベースの接続情報
+define( 'DB_HOST', 'localhost');
+define( 'DB_USER', 'root');
+define( 'DB_PASS', 'root');
+define( 'DB_NAME', 'board');
+
+// タイムゾーン設定
+date_default_timezone_set('Asia/Tokyo');
+
+// 変数の初期化
+$current_date = null;
+$message = array();
+$message_array = array();
+$error_message = array();
+$pdo = null;
+$stmt = null;
+$res = null;
+$option = null;
+
+session_start();
+
+// データベースに接続
+try {
+
+    $option = array(
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::MYSQL_ATTR_MULTI_STATEMENTS => false
+    );
+    $pdo = new PDO('mysql:charset=UTF8;dbname='.DB_NAME.';host='.DB_HOST , DB_USER, DB_PASS, $option);
+
+} catch(PDOException $e) {
+
+    // 接続エラーのときエラー内容を取得する
+    $error_message[] = $e->getMessage();
+}
+
+
+  
+  if( !empty($_POST['search_word']) ){
+      if($_POST['search_word'] === "adminUser"){
+        header('Location: ./admin.php');
+        exit;
+
+      }else{
+        $sql = 
+        "
+          SELECT * FROM message
+          WHERE view_name LIKE '%" . $_POST["search_word"] . "%'
+          OR message LIKE '%" . $_POST["search_word"] . "%'
+        ";
+
+        $search_word = $_POST['search_word'];
+        $message_array = $pdo -> query($sql);
+      }
+    }
+
+  // disconnect db
+  $pdo = null;
+  
+
+?>

--- a/search_view.php
+++ b/search_view.php
@@ -1,0 +1,50 @@
+<?php
+  require('./search_process.php');
+?>
+
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ひと言掲示板｜検索結果</title>
+<style>
+  <?php
+    require('./main.css');
+  ?>
+
+  .menubar{
+    margin: 0 0 20px 0;
+  }
+  
+</style>
+</head>
+<body>
+<h1>ひと言掲示板｜検索結果</h1>
+
+<div class="menubar">
+  <a href="./index.php">top</a>
+</div>
+
+  <h2>検索ワード【 <?php echo $search_word ?> 】</h2>
+
+  <?php if(!empty($message_array)){ ?>
+    <?php foreach( $message_array as $value){ ?>
+    <!-- message -->
+      <article>
+        <div class="info">
+          <h2><?php echo htmlspecialchars($value['view_name'],ENT_QUOTES,'UTF-8');?></h2>
+          <time><?php echo date('Y年m月d日 H:i', strtotime($value['post_date']));?></time>
+        </div>
+        <p>
+          <?php echo nl2br(htmlspecialchars($value['message'],ENT_QUOTES,'UTF-8')); ?>
+        </p>
+        <form method="post" action="alert_process.php">
+          <input type="hidden" name="alert_message" value="<?php if( !empty($value['id']) ){ echo htmlspecialchars( $value['id'], ENT_QUOTES, 'UTF-8'); } ?>">
+          <input type="submit" name="btn_alert" value="通報">
+        </form>
+      </article>
+    <?php } ;?>
+  <?php }; ?>
+</section>
+</body>
+</html>


### PR DESCRIPTION
## チケットへのリンク

*  なし

## やったこと

* 検索欄に入力すると、メッセージ・ユーザーネームから検索ワードに該当するものを抽出して表示する
* `adminUser`と検索欄に入力すると管理ページに飛べる（隠しコマンド）

## やらないこと

* なし

## 動作確認

■検索欄の設置
![image](https://user-images.githubusercontent.com/83944000/121648497-8b10a980-cad2-11eb-9776-73e88ac691e4.png)

■検索結果あり
![image](https://user-images.githubusercontent.com/83944000/121648551-995ec580-cad2-11eb-97e9-7cc1d8351527.png)

■検索結果なし
![image](https://user-images.githubusercontent.com/83944000/121648608-a7ace180-cad2-11eb-98c7-360aad7eff7e.png)


## その他

* なし

## Mergeをする前に

- [x] 今回の変更により影響がある部分をテストして動作確認済みです
- [x] 最新の変更を全て取り込んで反映しています